### PR TITLE
Prevent infinite loop and use correct `subscribers` method

### DIFF
--- a/src/Resources/EmailList.php
+++ b/src/Resources/EmailList.php
@@ -2,6 +2,8 @@
 
 namespace Spatie\MailcoachSdk\Resources;
 
+use Spatie\MailcoachSdk\Support\PaginatedResults;
+
 class EmailList extends ApiResource
 {
     public string $uuid;
@@ -60,11 +62,11 @@ class EmailList extends ApiResource
 
     /**
      * @param  array<string, string>  $filters
-     * @return array<int, Subscriber>
+     * @return \Spatie\MailcoachSdk\Support\PaginatedResults
      */
-    public function subscribers(array $filters = []): array
+    public function subscribers(array $filters = []): PaginatedResults
     {
-        return $this->subscribers($filters);
+        return $this->mailcoach->subscribers($this->uuid, $filters);
     }
 
     public function subscriber(string $email): ?Subscriber


### PR DESCRIPTION
Hey!

Sorry for bombarding you with PRs across the different repos all at once haha!

This PR fixes a possible infinite loop that I've come across while working with the Laravel SDK.

First off, apologies if I've done any of this wrong. If it's something you might consider merging, please give me a shout if there's anything you might need changing 🙂

## Context

I have a Laravel artisan command that I run every day on my site that grabs the total amount of subscribers for my newsletter and then stores it in the database. I'm currently using Revue but I'm migrating over to using Mailcoach.

At first, I tried using the following code, but I kept getting `0` as the count:

```php
$subscriberCount = Mailcoach::emailList(config('services.mailcoach.newsletter_id'))
    ->activeSubscribersCount;
```

I'm not quite sure why I was getting 0, so I moved on to try a different method instead:

```php
$subscriberCount = Mailcoach::emailList(config('services.mailcoach.newsletter_id'))
    ->subscribers()
    ->total();
```

The call to `subscribers` is where the issue occurs.

## The Issue

It seems that the `subscribers` method calls itself and ends up in an infinite loop which eventually breaks.

I copied the approach used in the `subscriber` method in the `EmailList` and passed the `subscribers` call through to the `$this->mailcoach` object instead. This appears to then fetch the correct data as intended.

I also updated the method's return type so that it would return a `PaginatedResults` object instead. I don't know if this is okay to do, or whether it would have been better to return an array instead to prevent the breaking change.

Hopefully, the changes I've done are all okay. But, as I say, please give me a shout if there's anything you might want me to change if you think it's worth merging 😄