### PR TITLE
URLencode filter values

### DIFF
--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -71,8 +71,8 @@ trait MakesHttpRequests
         }
 
         $preparedFilters = [];
-        foreach ($filters as $name => $value) {
-            $preparedFilters["filter[{$name}]"] = $value;
+        foreach ($filters as $name => $value) {            
+            $preparedFilters["filter[{$name}]"] = urlencode($value);
         }
 
         return '?'.http_build_query($preparedFilters);


### PR DESCRIPTION
E-mail addresses can contain '+' signs, which get converted back into a space ' ' when filtering. This causes the subscriber lookup to fail:

$subscriber = $emailList->subscriber($user->email);

..because the + sign in the email is not there anymore.

A urlencode here prevents confusion in the encoding that happens in http_build_query.

If this causes unexpected behaviour with other filters, I'd advise to update the documentation and instruct users to urlencode the value on their end.