### PR TITLE
fix: Problems with finding subscribers with "+" character in their emails

### DIFF
--- a/src/Actions/ManagesSubscribers.php
+++ b/src/Actions/ManagesSubscribers.php
@@ -36,7 +36,9 @@ trait ManagesSubscribers
 
     public function findByEmail(string $emailListUuid, string $email): ?Subscriber
     {
-        $subscribers = $this->get("email-lists/{$emailListUuid}/subscribers?filter[email]={$email}")['data'];
+        $encoded = urlencode($email);
+
+        $subscribers = $this->get("email-lists/{$emailListUuid}/subscribers?filter[email]={$encoded}")['data'];
 
         if (count($subscribers) === 0) {
             return null;

--- a/src/Actions/ManagesSubscribers.php
+++ b/src/Actions/ManagesSubscribers.php
@@ -36,9 +36,9 @@ trait ManagesSubscribers
 
     public function findByEmail(string $emailListUuid, string $email): ?Subscriber
     {
-        $encoded = urlencode($email);
+        $email = urlencode($email);
 
-        $subscribers = $this->get("email-lists/{$emailListUuid}/subscribers?filter[email]={$encoded}")['data'];
+        $subscribers = $this->get("email-lists/{$emailListUuid}/subscribers?filter[email]={$email}")['data'];
 
         if (count($subscribers) === 0) {
             return null;


### PR DESCRIPTION
Hi!
I've found an issue with your SDK. 
<img width="860" alt="image" src="https://github.com/spatie/mailcoach-sdk-php/assets/5730766/8d160968-692e-4037-a192-40fd6273d4b5">

When trying to find a subscriber who has "+" sign in their address, it returns a "null", however if we encode the value first, it works as expected. I've created a simple fix.

Have a good day!