### PR TITLE
retrieve opens, clicks, unsubscribes and bounces for a given campaign

### DIFF
--- a/src/Actions/ManagesCampaigns.php
+++ b/src/Actions/ManagesCampaigns.php
@@ -3,6 +3,10 @@
 namespace Spatie\MailcoachSdk\Actions;
 
 use Spatie\MailcoachSdk\Resources\Campaign;
+use Spatie\MailcoachSdk\Resources\CampaignBounce;
+use Spatie\MailcoachSdk\Resources\CampaignClick;
+use Spatie\MailcoachSdk\Resources\CampaignOpen;
+use Spatie\MailcoachSdk\Resources\CampaignUnsubscribe;
 use Spatie\MailcoachSdk\Support\PaginatedResults;
 
 trait ManagesCampaigns
@@ -54,5 +58,41 @@ trait ManagesCampaigns
     public function send(string $campaignUuid): void
     {
         $this->post("campaigns/{$campaignUuid}/send");
+    }
+
+    public function campaignOpens(string $campaignUuid): PaginatedResults
+    {
+        return PaginatedResults::make(
+            "campaigns/{$campaignUuid}/opens",
+            CampaignOpen::class,
+            $this,
+        );
+    }
+
+    public function campaignClicks(string $campaignUuid): PaginatedResults
+    {
+        return PaginatedResults::make(
+            "campaigns/{$campaignUuid}/clicks",
+            CampaignClick::class,
+            $this,
+        );
+    }
+
+    public function campaignUnsubscribes(string $campaignUuid): PaginatedResults
+    {
+        return PaginatedResults::make(
+            "campaigns/{$campaignUuid}/unsubscribes",
+            CampaignUnsubscribe::class,
+            $this,
+        );
+    }
+
+    public function campaignBounces(string $campaignUuid): PaginatedResults
+    {
+        return PaginatedResults::make(
+            "campaigns/{$campaignUuid}/bounces",
+            CampaignBounce::class,
+            $this,
+        );
     }
 }

--- a/src/Resources/CampaignBounce.php
+++ b/src/Resources/CampaignBounce.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\MailcoachSdk\Resources;
+
+class CampaignBounce extends ApiResource
+{
+    public string $subscriberUuid;
+    public string $subscriberEmailListUuid;
+    public string $subscriberEmail;
+    public int $bounceCount;
+    public string $type;
+    public string $createdAt;
+}

--- a/src/Resources/CampaignClick.php
+++ b/src/Resources/CampaignClick.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Spatie\MailcoachSdk\Resources;
+
+class CampaignClick extends ApiResource
+{
+    public string $uuid;
+    public string $url;
+    public int $uniqueClickCount;
+    public int $clickCount;
+}

--- a/src/Resources/CampaignOpen.php
+++ b/src/Resources/CampaignOpen.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Spatie\MailcoachSdk\Resources;
+
+class CampaignOpen extends ApiResource
+{
+    public ?string $uuid;
+    public string $subscriberEmailListUuid;
+    public string $subscriberUuid;
+    public string $subscriberEmail;
+    public int $openCount;
+    public string $firstOpenedAt;
+}

--- a/src/Resources/CampaignUnsubscribe.php
+++ b/src/Resources/CampaignUnsubscribe.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace Spatie\MailcoachSdk\Resources;
+
+class CampaignUnsubscribe extends ApiResource
+{
+    public string $campaignUuid;
+    public string $subscriberUuid;
+    public string $subscriberEmail;
+}


### PR DESCRIPTION
Some endpoints return undocumented attributes.

### Opens
endpoint `/opens` returns :
- `uuid`
- `subscriberEmailListUuid`

and [docs](https://mailcoach.app/docs/self-hosted/v6/using-mailcoach/using-the-api/campaigns#content-getting-a-sent-campaigns-opens) mentions a `subscriber_id` instead of `subscriber_uuid`

![Screenshot 2023-08-24 at 11-50-59 Campaigns Docs Mailcoach](https://github.com/spatie/mailcoach-sdk-php/assets/2412608/2ed30541-515c-4438-8c38-6e7df05596f1)


### Clicks
endpoint `/clicks` returns :
- `uuid`


### Unsubscribes
endpoint `/unsubscribes` returns :
- `campaign` (with the whole campaign object !?)
- `subscriber` (with the whole subscriber object !?)

and [docs](https://mailcoach.app/docs/self-hosted/v6/using-mailcoach/using-the-api/campaigns#content-getting-a-sent-campaigns-unsubscribes) mentions a `subscriber_id` instead of `subscriber_uuid` and `campaign_id` instead of `campaign_uuid`

![Screenshot 2023-08-24 at 11-56-20 Campaigns Docs Mailcoach](https://github.com/spatie/mailcoach-sdk-php/assets/2412608/a271ecf6-2e28-40b7-b7a3-c42c28da2b40)


### Bounces
endpoint `/bounces` returns :
- `createdAt`