### PR TITLE
Fix data retrieval when creating a campaign

### DIFF
--- a/src/Actions/ManagesCampaigns.php
+++ b/src/Actions/ManagesCampaigns.php
@@ -29,7 +29,7 @@ trait ManagesCampaigns
 
     public function createCampaign(array $data): Campaign
     {
-        $attributes = $this->post('campaigns', $data);
+        $attributes = $this->post('campaigns', $data)['data'];
 
         return new Campaign($attributes, $this);
     }


### PR DESCRIPTION
When creating a campaign, the data is not retrieved correctly; like in the other methods, it should unwrap the data from the `data` property.