### PR TITLE
Fix #34 -- Added a isSubscribed method on the Subscriber resource

### DIFF
--- a/src/Resources/Subscriber.php
+++ b/src/Resources/Subscriber.php
@@ -49,6 +49,11 @@ class Subscriber extends ApiResource
         return $this;
     }
 
+    public function isSubscribed(): bool
+    {
+        return $this->unsubscribedAt === null;
+    }
+
     public function unsubscribe(): self
     {
         $this->mailcoach->unsubscribeSubscriber($this->uuid);


### PR DESCRIPTION
Fix #34. Adds a method (isSubscribed) on the Subscriber resource that checks the unsubscribedAt property. This simply assumes that if the unsubscribedAt is not null, then the subscriber is unsubscribed, in other words it doesn't check the actual timestamp set. 

I believe this is a little simpler implementation than #35. 

Let me know, what you think. 