### PR TITLE
added Unsubscribe by Email method

### DIFF
--- a/src/Resources/EmailList.php
+++ b/src/Resources/EmailList.php
@@ -90,4 +90,9 @@ class EmailList extends ApiResource
 
         return $this;
     }
+
+    public function unsubscribe(string $email)
+    {
+        return $this->mailcoach->post("email-lists/{$this->uuid}/unsubscribe", ['email' => $email]);
+    }
 }


### PR DESCRIPTION
https://mailcoach.app/api-documentation/endpoints/subscribers#content-unsubscribe-a-subscriber

There is API functionality that can unsubscribe by only email when you do not know the subscriber uuid. This method provides that.

Btw the API doc giving wrong reference API endpoint for that, It would be nice if can be fixed.
![image](https://github.com/spatie/mailcoach-sdk-php/assets/21062398/da078b09-793f-4fed-bb36-d43f0109b967)
