### PR TITLE
feat: Add rate limited exception

### DIFF
--- a/src/Exceptions/RateLimited.php
+++ b/src/Exceptions/RateLimited.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Spatie\MailcoachSdk\Exceptions;
+
+use Exception;
+
+class RateLimited extends Exception
+{
+    public function __construct(
+        public int $retryAfter
+    ) {
+        parent::__construct("The request was rate limited. Retry in {$this->retryAfter} seconds.");
+    }
+}

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -6,6 +6,7 @@ use Exception;
 use Psr\Http\Message\ResponseInterface;
 use Spatie\MailcoachSdk\Exceptions\ActionFailed;
 use Spatie\MailcoachSdk\Exceptions\InvalidData;
+use Spatie\MailcoachSdk\Exceptions\RateLimited;
 use Spatie\MailcoachSdk\Exceptions\ResourceNotFound;
 use Spatie\MailcoachSdk\Exceptions\Unauthorized;
 
@@ -80,6 +81,10 @@ trait MakesHttpRequests
 
     protected function handleRequestError(ResponseInterface $response): void
     {
+        if ($response->getStatusCode() === 429) {
+            throw new RateLimited(intval($response->getHeader('Retry-After')[0] ?? 60));
+        }
+
         if ($response->getStatusCode() === 422) {
             throw new InvalidData(json_decode((string) $response->getBody(), true));
         }

--- a/src/MakesHttpRequests.php
+++ b/src/MakesHttpRequests.php
@@ -82,7 +82,7 @@ trait MakesHttpRequests
     protected function handleRequestError(ResponseInterface $response): void
     {
         if ($response->getStatusCode() === 429) {
-            throw new RateLimited(intval($response->getHeader('Retry-After')[0] ?? 60));
+            throw new RateLimited(intval($response->getHeader('Retry-After')[0] ?? -1));
         }
 
         if ($response->getStatusCode() === 422) {

--- a/tests/MakesHttpRequestsTest.php
+++ b/tests/MakesHttpRequestsTest.php
@@ -22,8 +22,14 @@ it('throws a rate limited exception when 429 response code', function () {
     ]);
 
     $mailcoach = new Mailcoach('fake-token', 'fake-uri', $client);
-    $mailcoach->get('/');
-})->throws(RateLimited::class, 'The request was rate limited. Retry in 45 seconds.');
+
+    try {
+        $mailcoach->get('/');
+    } catch (RateLimited $ex) {
+        expect($ex->getMessage())->toBe('The request was rate limited. Retry in 45 seconds.');
+        expect($ex->retryAfter)->toBe(45);
+    }
+});
 
 it('handles when Retry-After is not present when 429 response code', function () {
     $client = mockClient([
@@ -31,8 +37,14 @@ it('handles when Retry-After is not present when 429 response code', function ()
     ]);
 
     $mailcoach = new Mailcoach('fake-token', 'fake-uri', $client);
-    $mailcoach->get('/');
-})->throws(RateLimited::class, 'The request was rate limited. Retry in 60 seconds.');
+
+    try {
+        $mailcoach->get('/');
+    } catch (RateLimited $ex) {
+        expect($ex->getMessage())->toBe('The request was rate limited. Retry in -1 seconds.');
+        expect($ex->retryAfter)->toBe(-1);
+    }
+});
 
 function mockClient(array $responses): ClientInterface
 {

--- a/tests/MakesHttpRequestsTest.php
+++ b/tests/MakesHttpRequestsTest.php
@@ -1,5 +1,11 @@
 <?php
 
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface;
+use GuzzleHttp\Handler\MockHandler;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Psr7\Response;
+use Spatie\MailcoachSdk\Exceptions\RateLimited;
 use Spatie\MailcoachSdk\Mailcoach;
 
 it('does not double encode', function () {
@@ -9,3 +15,29 @@ it('does not double encode', function () {
         'email' => 'info@spatie.be',
     ]))->toBe('?filter%5Bemail%5D=info%40spatie.be');
 });
+
+it('throws a rate limited exception when 429 response code', function () {
+    $client = mockClient([
+        new Response(429, ['Retry-After' => 45]),
+    ]);
+
+    $mailcoach = new Mailcoach('fake-token', 'fake-uri', $client);
+    $mailcoach->get('/');
+})->throws(RateLimited::class, 'The request was rate limited. Retry in 45 seconds.');
+
+it('handles when Retry-After is not present when 429 response code', function () {
+    $client = mockClient([
+        new Response(429),
+    ]);
+
+    $mailcoach = new Mailcoach('fake-token', 'fake-uri', $client);
+    $mailcoach->get('/');
+})->throws(RateLimited::class, 'The request was rate limited. Retry in 60 seconds.');
+
+function mockClient(array $responses): ClientInterface
+{
+    return new Client([
+        'handler' => HandlerStack::create(new MockHandler($responses)),
+        'http_errors' => false,
+    ]);
+}


### PR DESCRIPTION
We are currently implementing Mailcoach in our Laravel app and were looking at implementing handling Mailcoach's rate limits with our jobs/queues but this SDK wasn't handling a `429`. It was just throwing a generic `Exception`.

Following the [Rate limiting docs](https://www.mailcoach.app/api-documentation/introduction/authentication/#content-rate-limiting), we added a `RateLimited` exception.